### PR TITLE
fix: zen-command-palette.uc.js, remove problomatic observer

### DIFF
--- a/mods/zen-command-palette/zen-command-palette.uc.js
+++ b/mods/zen-command-palette/zen-command-palette.uc.js
@@ -1634,12 +1634,6 @@
         }
       });
 
-      observer.observe(results, {
-        childList: true,
-        subtree: true,
-        attributes: true,
-        attributeFilter: ["selected"],
-      });
       observer.observe(urlbar, { attributes: true, attributeFilter: ["open"] });
       debugLog("Scroll handling and MutationObserver successfully initialized.");
     },


### PR DESCRIPTION
Apparently it works without the observer.