### PR TITLE
add CMI to marketplace.json

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -425,5 +425,18 @@
       "zen",
       "firefox"
     ]
-  }
+  },
+  "Context-Menu-Icons": {
+    "homepage": "Starry-AXQG/Context-Menu-Icons",
+    "image": "https://raw.githubusercontent.com/Starry-AXQG/Context-Menu-Icons/refs/heads/main/.asset/Demo%20Image.jpg",
+    "name": "Context Menu Icons",
+    "version": "2.1",
+    "description": "Improve the context menu by adding icons, fold menu items and more.",
+    "readme": "https://raw.githubusercontent.com/rasyidrafi/zen-compact-transparent-mode/refs/heads/main/README.md",
+    "stars": 0,
+    "fork": [
+      "zen",
+      "firefox"
+    ]
+}
 }


### PR DESCRIPTION
add CMI to marketplace.json
I noticed that all the mods that can normally pull in JS are included in this list. Therefore, I think some information about CMI should be added to the marketplace.json.