### PR TITLE
Add Blended Addressbar mod

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -284,6 +284,7 @@
     "image": "https://raw.githubusercontent.com/kkugot/blended-addressbar/main/marketplace-preview.png",
     "author": "Kostiantyn Kugot",
     "version": "1.0.0",
+    "ai": "partial",
     "createdAt": "2026-01-29",
     "updatedAt": "2026-05-13",
     "style": {
@@ -309,7 +310,6 @@
     "fork": [
       "zen"
     ],
-    "js": true,
     "stars": 0
   },
   "zaps-cool-photon-theme": {

--- a/marketplace.json
+++ b/marketplace.json
@@ -283,7 +283,7 @@
     "readme": "https://raw.githubusercontent.com/kkugot/blended-addressbar/main/README.md",
     "image": "https://raw.githubusercontent.com/kkugot/blended-addressbar/main/marketplace-preview.png",
     "author": "Kostiantyn Kugot",
-    "version": "0.9.4",
+    "version": "1.0.0",
     "createdAt": "2026-01-29",
     "updatedAt": "2026-05-13",
     "style": {

--- a/marketplace.json
+++ b/marketplace.json
@@ -275,6 +275,43 @@
     ],
     "stars": 376
   },
+  "blended-addressbar": {
+    "id": "blended-addressbar",
+    "name": "Blended Addressbar",
+    "description": "A page-aware addressbar that blends Zen chrome with the active website.",
+    "homepage": "https://github.com/kkugot/blended-addressbar",
+    "readme": "https://raw.githubusercontent.com/kkugot/blended-addressbar/main/README.md",
+    "image": "https://raw.githubusercontent.com/kkugot/blended-addressbar/main/marketplace-preview.png",
+    "author": "Kostiantyn Kugot",
+    "version": "0.9.4",
+    "createdAt": "2026-01-29",
+    "updatedAt": "2026-05-13",
+    "style": {
+      "chrome": "style.css",
+      "content": ""
+    },
+    "scripts": {
+      "blended-bar.uc.js": {
+        "include": [
+          "chrome://browser/content/browser.xhtml"
+        ]
+      }
+    },
+    "preferences": "preferences.json",
+    "tags": [
+      "addressbar",
+      "urlbar",
+      "sidebar",
+      "adaptive",
+      "theming",
+      "zen browser"
+    ],
+    "fork": [
+      "zen"
+    ],
+    "js": true,
+    "stars": 0
+  },
   "zaps-cool-photon-theme": {
     "id": "zaps-cool-photon-theme",
     "name": "zap's cool photon theme",


### PR DESCRIPTION
Adds Blended Addressbar to the Sine marketplace.
Metadata points to the public mod repository and a 600x400 transparent-padded marketplace preview image.