### PR TITLE
Add missing homepage to zen-page-tint entry

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -1853,6 +1853,7 @@
   },
   "zen-page-tint": {
     "id": "zen-page-tint",
+    "homepage": "https://github.com/caezium/zen-page-tint",
     "name": "Zen Page Tint",
     "description": "Adaptive Zen chrome color from the active page. Single rAF-coalesced sampler, per-origin LRU cache, no retry storms, no per-tab paint cascade. Built for heavy-tab sessions.",
     "author": "caezium",


### PR DESCRIPTION
## Add missing `homepage` to the `zen-page-tint` entry

`zen-page-tint` is currently the only entry of 62 in `marketplace.json` without a `homepage` field. Because `update-marketplace.yml`'s **Resolve GitHub repo** step reads `homepage` from `marketplace.json` to locate the repo, the missing value makes it bail (`No homepage…` → `exit 0`) without setting `$repo` — then **Process mod** (`set -euo pipefail`) hits `repo: unbound variable` and the run fails. That's the failure in run #30447, and it recurs every time the scheduler's round-robin cursor reaches this mod.

This adds the one missing line. The theme's upstream `theme.json` now carries the same `homepage`, so it persists when the entry is rebuilt from `theme.json` during processing.

### Notes for maintainers
- Merging this fixes the entry and stops the recurring resolve crash.
- The Update marketplace run auto-triggered by **this** merge may fail with a permissions error — this is a PR from a fork, so its `GITHUB_TOKEN` is read-only. That's expected/harmless and doesn't affect the merged change.
- To finish processing (download mod files into `mods/zen-page-tint/`, still missing), please re-run **Update marketplace** via `workflow_dispatch` with `mod_id=zen-page-tint`. The leftover `mod/zen-page-tint` branch may need deleting first so the bot regenerates it cleanly.

Thanks! 🙏
