### PR TITLE
Add image (social card) to zen-page-tint entry

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -866,6 +866,7 @@
     "description": "Adaptive Zen chrome color from the active page. Single rAF-coalesced sampler, per-origin LRU cache, no retry storms, no per-tab paint cascade. Built for heavy-tab sessions.",
     "author": "caezium",
     "homepage": "https://github.com/caezium/zen-page-tint",
+    "image": "https://raw.githubusercontent.com/caezium/zen-page-tint/main/assets/social.jpg",
     "version": "1.2.0",
     "tags": [
       "adaptive",


### PR DESCRIPTION
Adds the missing `image` field to the `zen-page-tint` marketplace entry — the store card currently shows "Image not found". Points at the repo's social card:

https://raw.githubusercontent.com/caezium/zen-page-tint/main/assets/social.jpg

Heads up (same as the homepage PR #958): merging this triggers `update-marketplace` with a read-only fork token, so that auto-run will 403 on push — harmless, the `image` field is applied by the merge itself, nothing else is committed. Thanks!