### PR TITLE
Add Blended Addressbar preview image

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -1042,6 +1042,7 @@
     },
     "preferences": "preferences.json",
     "readme": "https://raw.githubusercontent.com/kkugot/blended-addressbar/main/README.md",
+    "image": "https://raw.githubusercontent.com/kkugot/blended-addressbar/main/marketplace-preview.png",
     "createdAt": "2026-01-29",
     "homepage": "https://github.com/kkugot/blended-addressbar",
     "stars": 19,


### PR DESCRIPTION
Add the existing 600 × 400 Blended Addressbar preview to its marketplace entry. The entry currently has no `image` field, so the store shows its fallback image.

The only marketplace change is:
`https://raw.githubusercontent.com/kkugot/blended-addressbar/main/marketplace-preview.png`

**Merge after https://github.com/kkugot/blended-addressbar/pull/16.** That PR adds the same URL to the source `theme.json`. The store updater replaces the entry from that manifest, so merging the source first prevents a refresh from removing the image.

Validation: the image URL returns HTTP 200; JSON parses; comparison with the base confirms that only this entry's image field changed; `git diff --check` passes.
